### PR TITLE
Hyperparam callable improvements

### DIFF
--- a/examples/cnn_utils/optimizers.py
+++ b/examples/cnn_utils/optimizers.py
@@ -59,7 +59,7 @@ def get_optimizer(
             damping=args.kfac_damping,
             factor_decay=args.kfac_factor_decay,
             kl_clip=args.kfac_kl_clip,
-            lr=lambda: optimizer.param_groups[0]['lr'],
+            lr=lambda x: optimizer.param_groups[0]['lr'],
             accumulation_steps=args.batches_per_allreduce,
             allreduce_bucket_cap_mb=25,
             colocate_factors=args.kfac_colocate_factors,

--- a/kfac/hyperparams.py
+++ b/kfac/hyperparams.py
@@ -1,0 +1,44 @@
+"""Common hyperparameter schedules."""
+from __future__ import annotations
+
+from typing import Callable
+
+
+def exp_decay_factor_averaging(
+    min_value: float = 0.95,
+) -> Callable[[int], float]:
+    """Exponentially decaying factor averaging schedule.
+
+    Implements the running average estimate strategy for the Kronecker factors
+    A and G from "Optimizing Neural Networks with Kronecker-factored
+    Approximate Curvature" (Martens et al., 2015).
+
+    The running average weight e at K-FAC step k is min(1 - 1/k, min_value)
+    where the min_value is 0.95 by default.
+
+    Args:
+        min_value (float): minimum value for the running average weight.
+
+    Returns:
+        callable that takes an integer value for the current K-FAC step and
+        returns a float value for the running average weight. This callable
+        can be passed as the value of `factor_decay` to instances of
+        `kfac.base_preconditioner.BaseKFACPreconditioner`. Note: that if the
+        current step is 0, 1 / k is undefined so k = 1 will be used,
+        and if the current step is negative, a ValueError will be raised.
+
+    Raises:
+        ValueError:
+            if `min_value` is less than or equal to zero.
+    """
+    if min_value <= 0:
+        raise ValueError('min_value must be greater than 0')
+
+    def _factor_weight(step: int) -> float:
+        if step < 0:
+            raise ValueError(f'step value cannot be negative. Got {step=}.')
+        if step == 0:
+            step = 1
+        return min(1 - (1 / step), min_value)
+
+    return _factor_weight

--- a/kfac/preconditioner.py
+++ b/kfac/preconditioner.py
@@ -49,13 +49,13 @@ class KFACPreconditioner(BaseKFACPreconditioner):
         self,
         model: torch.nn.Module,
         *,
-        factor_update_steps: Callable[[], int] | int = 1,
-        inv_update_steps: Callable[[], int] | int = 1,
+        factor_update_steps: Callable[[int], int] | int = 1,
+        inv_update_steps: Callable[[int], int] | int = 1,
         # KFAC hyperparameters
-        damping: Callable[[], float] | float = 0.001,
-        factor_decay: Callable[[], float] | float = 0.95,
-        kl_clip: Callable[[], float] | float = 0.001,
-        lr: Callable[[], float] | float = 0.1,
+        damping: Callable[[int], float] | float = 0.001,
+        factor_decay: Callable[[int], float] | float = 0.95,
+        kl_clip: Callable[[int], float] | float = 0.001,
+        lr: Callable[[int], float] | float = 0.1,
         # Distribution strategy
         accumulation_steps: int = 1,
         allreduce_bucket_cap_mb: float = 25.0,
@@ -85,21 +85,21 @@ class KFACPreconditioner(BaseKFACPreconditioner):
             model (torch.nn.Module): model to precondition with KFAC.
             factor_update_steps (Callable, int): steps between computing and
                 updating the running average of the Kronecker factors or
-                callable that returns the value.
+                callable that takes the K-FAC step and returns the value.
             inv_update_steps (Callble, int): steps between recomputing and
                 communicating the second-order information or callable that
-                returns the value.
+                takes the K-FAC step and returns the value.
             damping (Callable, float): Tikhonov damping parameter or a callable
-                that will return the damping parameter as a float
-                (default: 0.001).
+                that takes the K-FAC step and returns the damping parameter
+                as a float (default: 0.001).
             factor_decay (Callable, float): running average coefficient for
-                Kronecker factors or callable that will return the factor_decay
-                (default: 0.95).
+                Kronecker factors or callable that takes the K-FAC step and
+                returns the factor_decay (default: 0.95).
             kl_clip (Callable, float): clipping parameter for gradient scaling
-                or a callable that returns a float. If None, no
-                scaling/clipping will be applied (default: 0.001).
-            lr (Callable, float): learning rate or callable that will return
-                learning rate (default: 0.1).
+                or a callable that takes the K-FAC step and returns a float.
+                If None, no scaling/clipping will be applied (default: 0.001).
+            lr (Callable, float): learning rate or callable that takes the
+                K-FAC step and returns learning rate (default: 0.1).
             accumulation_steps (int): number of forward/backward passes
                 between optimization steps (default: 1).
             allreduce_bucket_cap_mb (float): maximum size in megabytes for

--- a/tests/hyperparams_test.py
+++ b/tests/hyperparams_test.py
@@ -1,0 +1,46 @@
+"""Unit tests for kfac/hyperparams.py."""
+from __future__ import annotations
+
+import pytest
+
+from kfac.hyperparams import exp_decay_factor_averaging
+
+
+def test_exp_decay_factor_averaging_types() -> None:
+    """Test types and exceptions of exp_decay_factor_averaging()."""
+    assert callable(exp_decay_factor_averaging())
+    assert isinstance(exp_decay_factor_averaging()(1), float)
+    with pytest.raises(ValueError):
+        exp_decay_factor_averaging(0)
+    with pytest.raises(ValueError):
+        exp_decay_factor_averaging(-1)
+    with pytest.raises(ValueError):
+        exp_decay_factor_averaging()(-1)
+
+
+def test_exp_decay_factor_averaging_non_decreasing() -> None:
+    """Test exp_decay_factor_averaging() produces non decreasing values."""
+    func = exp_decay_factor_averaging()
+    values = [func(step) for step in range(1000)]
+    assert all(a <= b for a, b in zip(values, values[1:]))
+
+
+@pytest.mark.parametrize(
+    'min_value,values',
+    (
+        (
+            0.95,
+            [(0, 0), (1, 0), (5, 0.8), (10, 0.9), (100, 0.95), (1000, 0.95)],
+        ),
+        (0.1, [(1, 0), (10, 0.1), (100, 0.1), (1000, 0.1)]),
+        (1, [(1, 0), (10, 0.9), (100, 0.99)]),
+    ),
+)
+def test_exp_decay_factor_averaging_values(
+    min_value: float,
+    values: list[tuple[int, float]],
+) -> None:
+    """Test exp_decay_factor_averaging() input/outputs."""
+    func = exp_decay_factor_averaging(min_value)
+    for step, expected_value in values:
+        assert func(step) == expected_value

--- a/tests/integration/mnist_integration_test.py
+++ b/tests/integration/mnist_integration_test.py
@@ -124,7 +124,7 @@ def train_and_eval(precondition: bool, epochs: int) -> float:
             model,
             factor_update_steps=10,
             inv_update_steps=100,
-            lr=lambda: optimizer.param_groups[0]['lr'],
+            lr=lambda x: optimizer.param_groups[0]['lr'],
             update_factors_in_hook=False,
         )
     else:


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Hyperparam callables now take the current K-FAC step as input.
Added reference hyperparameter schedules.
Currently the only one is the exponentially decaying factor running average weight of Martens 2015.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->


### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Update existing unit tests and added new ones accordingly.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
