### PR TITLE
Remove tag from title in issue templates. Closes #45

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report errors or unexpected results.
-title: "[BUG]: "
 labels: ["bug"]
 assignees:
   - gpauloski

--- a/.github/ISSUE_TEMPLATE/02_enchancement.yml
+++ b/.github/ISSUE_TEMPLATE/02_enchancement.yml
@@ -1,6 +1,5 @@
 name: Enhancement Request
 description: Request a new feature.
-title: "[ENHANCE]: "
 labels: ["enhancement"]
 assignees:
   - gpauloski

--- a/.github/ISSUE_TEMPLATE/03_docs.yml
+++ b/.github/ISSUE_TEMPLATE/03_docs.yml
@@ -1,6 +1,5 @@
 name: Documentation Improvements
 description: Suggest improvements to the documentation.
-title: "[DOCS]: "
 labels: ["documentation"]
 assignees:
   - gpauloski


### PR DESCRIPTION
Remove tag from title in issue templates because it is redundant with the GitHub tag.