### PR TITLE
Fix WorkAssignment usage in BaseKFACPreconditioner

### DIFF
--- a/tests/training_test.py
+++ b/tests/training_test.py
@@ -11,12 +11,12 @@ from testing.distributed import distributed_test
 from testing.models import TinyModel
 
 
-def train() -> None:
+def train(grad_worker_frac: float) -> None:
     """Train TinyModel with KFAC on random data."""
     batch_size = 4
     in_features = 10
     out_features = 10
-    epochs = 20
+    steps = 20
 
     x = torch.rand(batch_size, in_features)
     y = torch.rand(batch_size, out_features)
@@ -25,18 +25,21 @@ def train() -> None:
         torch.distributed.all_reduce(y)
 
     model = TinyModel()
+    if torch.distributed.is_initialized():
+        model = torch.nn.parallel.DistributedDataParallel(model)
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
     preconditioner = KFACPreconditioner(
         model,
         factor_update_steps=5,
         inv_update_steps=10,
+        grad_worker_fraction=grad_worker_frac,
         allreduce_bucket_cap_mb=0,
         update_factors_in_hook=False,
     )
     criterion = torch.nn.MSELoss(reduction='sum')
 
     losses = []
-    for _ in range(epochs):
+    for _ in range(steps):
         y_pred = model(x)
         loss = criterion(y_pred, y)
         losses.append(loss.item())
@@ -49,19 +52,23 @@ def train() -> None:
 
 
 @pytest.mark.parametrize(
-    'distributed,world_size',
-    ((False, 1), (True, 1), (True, 2), (True, 4)),
+    'distributed,grad_worker_frac,world_size',
+    ((False, 1, 1), (True, 0, 1), (True, 0.5, 2), (True, 0.5, 4)),
 )
-def test_training(distributed: bool, world_size: int) -> None:
+def test_training(
+    distributed: bool,
+    grad_worker_frac: float,
+    world_size: int,
+) -> None:
     """Test end-to-end training with KFACPreconditioner."""
     if not distributed:
         # Note: torch does not allow forking if autograd has been used
         # in the parent process. So we perform the training is a separate
         # process to keep this parent process "clean". See
         # https://github.com/pytorch/pytorch/issues/69839#issuecomment-993686048
-        p = Process(target=train)
+        p = Process(target=train, args=(grad_worker_frac,))
         p.start()
         p.join()
     else:
         _train = distributed_test(world_size=world_size)(train)
-        _train()
+        _train(grad_worker_frac)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Fixes `BaseKFACPreconditioner` not correctly using the provided `WorkAssignment` to divide work across workers. As a result, workers were redundantly performing the same tasks.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->


### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Updated `tests/training_tests.py` to use HYBRID-OPT to stress all code paths.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
