### PR TITLE
Python version compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,17 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
+          python: 3.7
+          toxenv: py37
+        - os: ubuntu-latest
+          python: 3.8
+          toxenv: py38
+        - os: ubuntu-latest
           python: 3.9
           toxenv: py39
+        - os: ubuntu-latest
+          python: '3.10'
+          toxenv: py310
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/kfac/base_preconditioner.py
+++ b/kfac/base_preconditioner.py
@@ -323,7 +323,7 @@ class BaseKFACPreconditioner:
             not self._update_factors_in_hook
             and self.steps % self.factor_update_steps == 0
         ):
-            for name, layer in reversed(self._layers.values()):
+            for name, layer in reversed(list(self._layers.values())):
                 self._mini_steps[name] = 0
                 layer.update_a_factor(alpha=self.factor_decay)
                 layer.reduce_a_factor()
@@ -336,7 +336,7 @@ class BaseKFACPreconditioner:
 
         # Compute Inverses
         if self.steps % self.inv_update_steps == 0:
-            for name, layer in reversed(self._layers.values()):
+            for name, layer in reversed(list(self._layers.values())):
                 if get_rank() == self._assignment.inv_worker(name, 'A'):
                     layer.compute_a_inv(damping=self.damping)
                 if (
@@ -360,7 +360,7 @@ class BaseKFACPreconditioner:
             self._tdc.flush_allreduce_buckets()
 
         # Compute Preconditioned Gradients
-        for name, layer in reversed(self._layers.values()):
+        for name, layer in reversed(list(self._layers.values())):
             if self._assignment.is_grad_worker(name):
                 layer.preconditioned_grad(damping=self.damping)
             if self._assignment.broadcast_gradients():
@@ -373,7 +373,7 @@ class BaseKFACPreconditioner:
         scale = None if self.kl_clip is None else self._compute_grad_scale()
 
         # Update gradients in-place
-        for _, layer in reversed(self._layers.values()):
+        for _, layer in reversed(list(self._layers.values())):
             layer.update_grad(scale=scale)
 
         self._steps += 1
@@ -413,7 +413,7 @@ class BaseKFACPreconditioner:
             sum_{layers} (sum_{gradients} precon_grad * grad * lr^2)
         """
         vg_sum = 0.0
-        for _, layer in reversed(self._layers.values()):
+        for _, layer in reversed(list(self._layers.values())):
             if layer.grad is None:
                 raise AssertionError(
                     'layer gradient has not been preconditioned',

--- a/kfac/hyperparams.py
+++ b/kfac/hyperparams.py
@@ -36,7 +36,9 @@ def exp_decay_factor_averaging(
 
     def _factor_weight(step: int) -> float:
         if step < 0:
-            raise ValueError(f'step value cannot be negative. Got {step=}.')
+            raise ValueError(
+                f'step value cannot be negative. Got step={step}.',
+            )
         if step == 0:
             step = 1
         return min(1 - (1 / step), min_value)

--- a/kfac/layers/base.py
+++ b/kfac/layers/base.py
@@ -239,8 +239,8 @@ class KFACBaseLayer:
         if self.grad is None:
             if get_rank() == src:
                 raise RuntimeError(
-                    f'Attempt to broadcast gradient from {src=} but this rank '
-                    'has not computed the preconditioned gradient yet.',
+                    f'Attempt to broadcast gradient from src={src} but this '
+                    'rank has not computed the preconditioned gradient yet.',
                 )
             self.grad = torch.empty_like(self.module.get_grad())
 
@@ -287,7 +287,9 @@ class KFACBaseLayer:
         elif self.allreduce_method == AllreduceMethod.ALLREDUCE_BUCKETED:
             allreduce = self.tdc.allreduce_bucketed
         else:
-            raise AssertionError('Unknown {self.allreduce_method=}')
+            raise AssertionError(
+                f'Unknown allreduce_method={self.allreduce_method}',
+            )
         self.a_factor = allreduce(
             self.a_factor,
             average=True,
@@ -307,7 +309,9 @@ class KFACBaseLayer:
         elif self.allreduce_method == AllreduceMethod.ALLREDUCE_BUCKETED:
             allreduce = self.tdc.allreduce_bucketed
         else:
-            raise AssertionError('Unknown {self.allreduce_method=}')
+            raise AssertionError(
+                f'Unknown allreduce_method={self.allreduce_method}',
+            )
         self.g_factor = allreduce(
             self.g_factor,
             average=True,

--- a/kfac/layers/eigen.py
+++ b/kfac/layers/eigen.py
@@ -196,7 +196,7 @@ class KFACEigenLayer(KFACBaseLayer):
         ):
             if get_rank() == src:
                 raise RuntimeError(
-                    f'Attempt to broadcast A inv from {src=} but this rank '
+                    f'Attempt to broadcast A inv from src={src} but this rank '
                     'has not computed A inv yet.',
                 )
             assert isinstance(self.a_factor, torch.Tensor)
@@ -239,7 +239,7 @@ class KFACEigenLayer(KFACBaseLayer):
         ):
             if get_rank() == src:
                 raise RuntimeError(
-                    f'Attempt to broadcast G inv from {src=} but this rank '
+                    f'Attempt to broadcast G inv from src={src} but this rank '
                     'has not computed G inv yet.',
                 )
             assert isinstance(self.g_factor, torch.Tensor)

--- a/kfac/layers/inverse.py
+++ b/kfac/layers/inverse.py
@@ -128,7 +128,7 @@ class KFACInverseLayer(KFACBaseLayer):
         if self.a_inv is None:
             if get_rank() == src:
                 raise RuntimeError(
-                    f'Attempt to broadcast A inv from {src=} but this rank '
+                    f'Attempt to broadcast A inv from src={src} but this rank '
                     'has not computed A inv yet.',
                 )
             assert isinstance(self.a_factor, torch.Tensor)
@@ -165,7 +165,7 @@ class KFACInverseLayer(KFACBaseLayer):
         if self.g_inv is None:
             if get_rank() == src:
                 raise RuntimeError(
-                    f'Attempt to broadcast G inv from {src=} but this rank '
+                    f'Attempt to broadcast G inv from src={src} but this rank '
                     'has not computed G inv yet.',
                 )
             assert isinstance(self.g_factor, torch.Tensor)

--- a/kfac/preconditioner.py
+++ b/kfac/preconditioner.py
@@ -246,7 +246,9 @@ class KFACPreconditioner(BaseKFACPreconditioner):
         elif self.compute_method == ComputeMethod.INVERSE:
             layer_type = KFACInverseLayer
         else:
-            raise AssertionError(f'Unknown {self.compute_method=}')
+            raise AssertionError(
+                f'Unknown compute_method={self.compute_method}',
+            )
 
         kfac_layers = register_modules(
             model,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,5 @@ pytest
 pytest-cov
 torchvision
 tox
+typing_extensions; python_version < "3.8"
 virtualenv

--- a/tests/layers/layers_test.py
+++ b/tests/layers/layers_test.py
@@ -1,9 +1,9 @@
 """Unit tests for implementations of KFACBaseLayer."""
 from __future__ import annotations
 
+import sys
 from typing import Any
 from typing import cast
-from typing import Literal
 from unittest import mock
 
 import pytest
@@ -18,6 +18,11 @@ from kfac.layers.eigen import KFACEigenLayer
 from kfac.layers.inverse import KFACInverseLayer
 from kfac.layers.modules import LinearModuleHelper
 from testing.distributed import distributed_test
+
+if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
+    from typing import Literal
+else:  # pragma: <3.8 cover
+    from typing_extensions import Literal
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, pre-commit
+envlist = py37, py38, py39, py310, pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Improve compatibility for Python versions (mostly 3.7).

- Removes self-documenting expressions in f-strings for Python 3.7 compatibility.
- Adds typing-extensions for Literal backport for Python 3.7 only.
- Cast `dict_values` to list before reversing for Python 3.7 mypy compatibility.
- Adds py37, py38, and py310 to the tox envlist.
- Adds the above tox recipes to the Github workflows.

### Fixes #54
<!--- List any issue numbers above that this PR addresses --->


### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [x] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

All test pass on Python 3.7, 3.8, 3.9, and 3.10.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
